### PR TITLE
feat(player): implemented PlayerService with CRUD, sorting, and top scorer logic

### DIFF
--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/CreatePlayerRequest.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/CreatePlayerRequest.java
@@ -1,0 +1,52 @@
+package com.nba.analyticshub.domain.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePlayerRequest {
+
+    @NotBlank(message = "Player name must be provided!")
+    @Size(min = 2, max = 75, message = "Player name must be between {min} and {max} characters")
+    private String name;
+
+    @NotBlank(message = "Nationality must be provided!")
+//    @Size(min = 2, max = 3, message = "Nationality must be between {min} and {max} characters")
+    @Pattern(regexp = "^[A-Z]{3}$", message = "Nationality must be a 3 uppercase letters country code like 'HUN'")
+    private String nation;
+
+    @NotNull(message = "Age must be provided")
+    @Min(value = 18, message = "Age must be at least {value}")
+    @Max(value = 55, message = "Age must not exceed {value}")
+    private Integer age;
+
+    @NotBlank(message = "Position must be provided!")
+    @Pattern(regexp = "^(PG|SG|SF|PF|C)$", message = "Position must be: PG, SG, SF, PF, C")
+    private String position;
+
+    @NotBlank(message = "Team name must be provided!")
+    @Size(min = 3, max = 75, message = "Team name must be between {min} and {max} characters")
+    @Pattern(regexp = "^[A-Za-z0-9\\s-]+$", message = "Team name can only contain letters, numbers, spaces and hyphens")
+    private String team;
+
+    @Min(value = 0, message = "Points cannot be negative")
+    private Integer points;
+
+    @Min(value = 0, message = "Assists cannot be negative")
+    private Integer assists;
+
+    @Min(value = 0, message = "Blocks cannot be negative")
+    private Integer blocks;
+
+    @Min(value = 0, message = "3-points shots made cannot be negative")
+    private Integer threePoints;
+
+    @Min(value = 0, message = "2-points shots made cannot be negative")
+    private Integer twoPoints;
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/CreatePlayerRequest.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/CreatePlayerRequest.java
@@ -49,4 +49,22 @@ public class CreatePlayerRequest {
 
     @Min(value = 0, message = "2-points shots made cannot be negative")
     private Integer twoPoints;
+
+    @Min(value = 0, message = "Number of games played cannot be negative")
+    private Integer gamesPlayed;
+
+    @Min(value = 0, message = "Number of games starts cannot be negative")
+    private Integer gameStarts;
+
+    @Min(value = 0, message = "Number of minutes played cannot be negative")
+    private Integer minutesPlayed;
+
+    @Min(value = 0, message = "Number of field goals made cannot be negative")
+    private Integer fieldGoals;
+
+    @Min(value = 0, message = "Number of steals cannot be negative")
+    private Integer steals;
+
+    @Min(value = 0, message = "Number of turnovers cannot be negative")
+    private Integer turnovers;
 }

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/PlayerDto.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/PlayerDto.java
@@ -1,0 +1,32 @@
+package com.nba.analyticshub.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlayerDto {
+    private UUID id;
+    private String name;
+    private String nation;
+    private Integer age;
+    private String position;
+    private Integer gamesPlayer;
+    private Integer gameStarts;
+    private Integer minutesPlayed;
+    private Integer fieldGoals;
+    private Integer threePoint;
+    private Integer twoPoint;
+    private Integer assists;
+    private Integer steals;
+    private Integer blocks;
+    private Integer turnovers;
+    private Integer points;
+    private String team;
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/PlayerDto.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/PlayerDto.java
@@ -21,8 +21,8 @@ public class PlayerDto {
     private Integer gameStarts;
     private Integer minutesPlayed;
     private Integer fieldGoals;
-    private Integer threePoint;
-    private Integer twoPoint;
+    private Integer threePoints;
+    private Integer twoPoints;
     private Integer assists;
     private Integer steals;
     private Integer blocks;

--- a/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
@@ -1,0 +1,81 @@
+package com.nba.analyticshub.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "player_statistic")
+public class Player {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "player_name")
+    private String name;
+
+    @Column(name = "nation")
+    private String nation;
+
+    @Column(name = "age")
+    private Integer age;
+
+    @Column(name = "position")
+    private String pos;
+
+    @Column(name = "games_played")
+    private Integer g;
+
+    @Column(name = "games_starts")
+    private Integer gs;
+
+    @Column(name = "minutes_played")
+    private Integer mp;
+
+    @Column(name = "field_goals")
+    private Integer fg;
+
+    @Column(name = "three_points")
+    private Integer threeP;
+
+    @Column(name = "two_points")
+    private Integer twoP;
+
+    @Column(name = "assists")
+    private Integer ast;
+
+    @Column(name = "steals")
+    private Integer stl;
+
+    @Column(name = "blocks")
+    private Integer blk;
+
+    @Column(name = "turnovers")
+    private Integer tov;
+
+    @Column(name = "points")
+    private Integer pts;
+
+    @Column(name = "team_name")
+    private String team;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Player player = (Player) o;
+        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(pos, player.pos) && Objects.equals(g, player.g) && Objects.equals(gs, player.gs) && Objects.equals(mp, player.mp) && Objects.equals(fg, player.fg) && Objects.equals(threeP, player.threeP) && Objects.equals(twoP, player.twoP) && Objects.equals(ast, player.ast) && Objects.equals(stl, player.stl) && Objects.equals(blk, player.blk) && Objects.equals(tov, player.tov) && Objects.equals(pts, player.pts) && Objects.equals(team, player.team);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, nation, age, pos, g, gs, mp, fg, threeP, twoP, ast, stl, blk, tov, pts, team);
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
@@ -32,37 +32,37 @@ public class Player {
     private String position;
 
     @Column(name = "games_played")
-    private Integer g;
+    private Integer gamesPlayed;
 
     @Column(name = "games_starts")
-    private Integer gs;
+    private Integer gameStarts;
 
     @Column(name = "minutes_played")
-    private Integer mp;
+    private Integer minutesPlayed;
 
     @Column(name = "field_goals")
-    private Integer fg;
+    private Integer fieldGoals;
 
     @Column(name = "three_points")
-    private Integer threeP;
+    private Integer threePoint;
 
     @Column(name = "two_points")
-    private Integer twoP;
+    private Integer twoPoint;
 
     @Column(name = "assists")
-    private Integer ast;
+    private Integer assists;
 
     @Column(name = "steals")
-    private Integer stl;
+    private Integer steals;
 
     @Column(name = "blocks")
-    private Integer blk;
+    private Integer blocks;
 
     @Column(name = "turnovers")
-    private Integer tov;
+    private Integer turnovers;
 
     @Column(name = "points")
-    private Integer pts;
+    private Integer points;
 
     @Column(name = "team_name")
     private String team;
@@ -71,11 +71,11 @@ public class Player {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Player player = (Player) o;
-        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(position, player.position) && Objects.equals(g, player.g) && Objects.equals(gs, player.gs) && Objects.equals(mp, player.mp) && Objects.equals(fg, player.fg) && Objects.equals(threeP, player.threeP) && Objects.equals(twoP, player.twoP) && Objects.equals(ast, player.ast) && Objects.equals(stl, player.stl) && Objects.equals(blk, player.blk) && Objects.equals(tov, player.tov) && Objects.equals(pts, player.pts) && Objects.equals(team, player.team);
+        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(position, player.position) && Objects.equals(gamesPlayed, player.gamesPlayed) && Objects.equals(gameStarts, player.gameStarts) && Objects.equals(minutesPlayed, player.minutesPlayed) && Objects.equals(fieldGoals, player.fieldGoals) && Objects.equals(threePoint, player.threePoint) && Objects.equals(twoPoint, player.twoPoint) && Objects.equals(assists, player.assists) && Objects.equals(steals, player.steals) && Objects.equals(blocks, player.blocks) && Objects.equals(turnovers, player.turnovers) && Objects.equals(points, player.points) && Objects.equals(team, player.team);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, nation, age, position, g, gs, mp, fg, threeP, twoP, ast, stl, blk, tov, pts, team);
+        return Objects.hash(id, name, nation, age, position, gamesPlayed, gameStarts, minutesPlayed, fieldGoals, threePoint, twoPoint, assists, steals, blocks, turnovers, points, team);
     }
 }

--- a/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
@@ -29,7 +29,7 @@ public class Player {
     private Integer age;
 
     @Column(name = "position")
-    private String pos;
+    private String position;
 
     @Column(name = "games_played")
     private Integer g;
@@ -71,11 +71,11 @@ public class Player {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Player player = (Player) o;
-        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(pos, player.pos) && Objects.equals(g, player.g) && Objects.equals(gs, player.gs) && Objects.equals(mp, player.mp) && Objects.equals(fg, player.fg) && Objects.equals(threeP, player.threeP) && Objects.equals(twoP, player.twoP) && Objects.equals(ast, player.ast) && Objects.equals(stl, player.stl) && Objects.equals(blk, player.blk) && Objects.equals(tov, player.tov) && Objects.equals(pts, player.pts) && Objects.equals(team, player.team);
+        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(position, player.position) && Objects.equals(g, player.g) && Objects.equals(gs, player.gs) && Objects.equals(mp, player.mp) && Objects.equals(fg, player.fg) && Objects.equals(threeP, player.threeP) && Objects.equals(twoP, player.twoP) && Objects.equals(ast, player.ast) && Objects.equals(stl, player.stl) && Objects.equals(blk, player.blk) && Objects.equals(tov, player.tov) && Objects.equals(pts, player.pts) && Objects.equals(team, player.team);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, nation, age, pos, g, gs, mp, fg, threeP, twoP, ast, stl, blk, tov, pts, team);
+        return Objects.hash(id, name, nation, age, position, g, gs, mp, fg, threeP, twoP, ast, stl, blk, tov, pts, team);
     }
 }

--- a/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/entity/Player.java
@@ -44,10 +44,10 @@ public class Player {
     private Integer fieldGoals;
 
     @Column(name = "three_points")
-    private Integer threePoint;
+    private Integer threePoints;
 
     @Column(name = "two_points")
-    private Integer twoPoint;
+    private Integer twoPoints;
 
     @Column(name = "assists")
     private Integer assists;
@@ -71,11 +71,11 @@ public class Player {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Player player = (Player) o;
-        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(position, player.position) && Objects.equals(gamesPlayed, player.gamesPlayed) && Objects.equals(gameStarts, player.gameStarts) && Objects.equals(minutesPlayed, player.minutesPlayed) && Objects.equals(fieldGoals, player.fieldGoals) && Objects.equals(threePoint, player.threePoint) && Objects.equals(twoPoint, player.twoPoint) && Objects.equals(assists, player.assists) && Objects.equals(steals, player.steals) && Objects.equals(blocks, player.blocks) && Objects.equals(turnovers, player.turnovers) && Objects.equals(points, player.points) && Objects.equals(team, player.team);
+        return Objects.equals(id, player.id) && Objects.equals(name, player.name) && Objects.equals(nation, player.nation) && Objects.equals(age, player.age) && Objects.equals(position, player.position) && Objects.equals(gamesPlayed, player.gamesPlayed) && Objects.equals(gameStarts, player.gameStarts) && Objects.equals(minutesPlayed, player.minutesPlayed) && Objects.equals(fieldGoals, player.fieldGoals) && Objects.equals(threePoints, player.threePoints) && Objects.equals(twoPoints, player.twoPoints) && Objects.equals(assists, player.assists) && Objects.equals(steals, player.steals) && Objects.equals(blocks, player.blocks) && Objects.equals(turnovers, player.turnovers) && Objects.equals(points, player.points) && Objects.equals(team, player.team);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, nation, age, position, gamesPlayed, gameStarts, minutesPlayed, fieldGoals, threePoint, twoPoint, assists, steals, blocks, turnovers, points, team);
+        return Objects.hash(id, name, nation, age, position, gamesPlayed, gameStarts, minutesPlayed, fieldGoals, threePoints, twoPoints, assists, steals, blocks, turnovers, points, team);
     }
 }

--- a/backend/src/main/java/com/nba/analyticshub/mapper/PlayerMapper.java
+++ b/backend/src/main/java/com/nba/analyticshub/mapper/PlayerMapper.java
@@ -1,0 +1,10 @@
+package com.nba.analyticshub.mapper;
+
+import com.nba.analyticshub.domain.dto.CreatePlayerRequest;
+import com.nba.analyticshub.domain.dto.PlayerDto;
+import com.nba.analyticshub.domain.entity.Player;
+
+public interface PlayerMapper {
+    PlayerDto toDto(Player player);
+    Player fromCreateRequest(CreatePlayerRequest request);
+}

--- a/backend/src/main/java/com/nba/analyticshub/mapper/mapperImpl/PlayerMapperImpl.java
+++ b/backend/src/main/java/com/nba/analyticshub/mapper/mapperImpl/PlayerMapperImpl.java
@@ -1,0 +1,56 @@
+package com.nba.analyticshub.mapper.mapperImpl;
+
+import com.nba.analyticshub.domain.dto.CreatePlayerRequest;
+import com.nba.analyticshub.domain.dto.PlayerDto;
+import com.nba.analyticshub.domain.entity.Player;
+import com.nba.analyticshub.mapper.PlayerMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlayerMapperImpl implements PlayerMapper {
+
+    @Override
+    public PlayerDto toDto(Player player) {
+        return PlayerDto.builder()
+                .id(player.getId())
+                .name(player.getName())
+                .nation(player.getNation())
+                .age(player.getAge())
+                .position(player.getPosition())
+                .gamesPlayer(player.getGamesPlayed())
+                .gameStarts(player.getGameStarts())
+                .minutesPlayed(player.getMinutesPlayed())
+                .fieldGoals(player.getFieldGoals())
+                .threePoints(player.getThreePoints())
+                .twoPoints(player.getTwoPoints())
+                .assists(player.getAssists())
+                .steals(player.getSteals())
+                .blocks(player.getBlocks())
+                .turnovers(player.getTurnovers())
+                .points(player.getPoints())
+                .team(player.getTeam())
+                .build();
+    }
+
+    @Override
+    public Player fromCreateRequest(CreatePlayerRequest request) {
+        return Player.builder()
+                .name(request.getName())
+                .nation(request.getNation().toUpperCase())
+                .age(request.getAge())
+                .position(request.getPosition())
+                .assists(request.getAssists())
+                .points(request.getPoints())
+                .team(request.getTeam())
+                .blocks(request.getBlocks())
+                .threePoints(request.getThreePoints())
+                .twoPoints(request.getTwoPoints())
+                .minutesPlayed(request.getMinutesPlayed())
+                .gameStarts(request.getGameStarts())
+                .fieldGoals(request.getFieldGoals())
+                .steals(request.getSteals())
+                .turnovers(request.getTurnovers())
+                .gamesPlayed(request.getGamesPlayed())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/repository/PlayerRepository.java
+++ b/backend/src/main/java/com/nba/analyticshub/repository/PlayerRepository.java
@@ -2,6 +2,7 @@ package com.nba.analyticshub.repository;
 
 import com.nba.analyticshub.domain.entity.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,9 +12,19 @@ import java.util.UUID;
 @Repository
 public interface PlayerRepository extends JpaRepository<Player, UUID> {
 
+    @Query("SELECT p FROM Player p ORDER BY p.points DESC")
+    List<Player> findTopScorer();
+
+    @Query("SELECT p FROM Player p ORDER BY p.name ASC")
+    List<Player> findAllByNameAsc();
+
+    @Query("SELECT p FROM Player p ORDER BY p.name DESC")
+    List<Player> findAllByNameDesc();
+
     Optional<Player> findByName(String name);
     List<Player> findByTeam(String team);
     List<Player> findByPosition(String position);
     List<Player> findByTeamAndPosition(String team, String position);
     List<Player> findByNationContainingIgnoreCase(String nation);
+    List<Player> findByNameContainingIgnoreCase(String name);
 }

--- a/backend/src/main/java/com/nba/analyticshub/repository/PlayerRepository.java
+++ b/backend/src/main/java/com/nba/analyticshub/repository/PlayerRepository.java
@@ -1,0 +1,19 @@
+package com.nba.analyticshub.repository;
+
+import com.nba.analyticshub.domain.entity.Player;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PlayerRepository extends JpaRepository<Player, UUID> {
+
+    Optional<Player> findByName(String name);
+    List<Player> findByTeam(String team);
+    List<Player> findByPosition(String position);
+    List<Player> findByTeamAndPosition(String team, String position);
+    List<Player> findByNationContainingIgnoreCase(String nation);
+}

--- a/backend/src/main/java/com/nba/analyticshub/service/PlayerService.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/PlayerService.java
@@ -1,0 +1,20 @@
+package com.nba.analyticshub.service;
+
+import com.nba.analyticshub.domain.dto.CreatePlayerRequest;
+import com.nba.analyticshub.domain.dto.PlayerDto;
+import com.nba.analyticshub.domain.entity.Player;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PlayerService {
+    List<PlayerDto> getAllPlayers();
+    List<PlayerDto> getTopScorers();
+    List<PlayerDto> getPlayersSortedByAsc();
+    List<PlayerDto> getPlayersSortedByDesc();
+    Player getPlayerById(UUID id);
+
+    PlayerDto createPlayer(CreatePlayerRequest request);
+    PlayerDto updatePlayer(UUID id, CreatePlayerRequest request);
+    void deletePlayer(UUID id);
+}

--- a/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/PlayerServiceImpl.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/PlayerServiceImpl.java
@@ -1,0 +1,102 @@
+package com.nba.analyticshub.service.serviceImpl;
+
+import com.nba.analyticshub.domain.dto.CreatePlayerRequest;
+import com.nba.analyticshub.domain.dto.PlayerDto;
+import com.nba.analyticshub.domain.entity.Player;
+import com.nba.analyticshub.mapper.PlayerMapper;
+import com.nba.analyticshub.repository.PlayerRepository;
+import com.nba.analyticshub.service.PlayerService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerServiceImpl implements PlayerService {
+
+    private final PlayerRepository playerRepository;
+    private final PlayerMapper playerMapper;
+
+    @Override
+    public List<PlayerDto> getAllPlayers() {
+        return playerRepository.findAll()
+                .stream()
+                .map(playerMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<PlayerDto> getTopScorers() {
+        return playerRepository.findTopScorer()
+                .stream()
+                .map(playerMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<PlayerDto> getPlayersSortedByAsc() {
+        return playerRepository.findAllByNameAsc()
+                .stream()
+                .map(playerMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<PlayerDto> getPlayersSortedByDesc() {
+        return playerRepository.findAllByNameDesc()
+                .stream()
+                .map(playerMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public Player getPlayerById(UUID id) {
+        return playerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Player with id " + id + " not found"));
+    }
+
+    @Override
+    public PlayerDto createPlayer(CreatePlayerRequest request) {
+        if (playerRepository.findByName(request.getName()).isPresent()) {
+            throw new ValidationException("Player already exists with name " + request.getName());
+        }
+
+        Player createdPlayer = playerRepository.save(playerMapper.fromCreateRequest(request));
+        return playerMapper.toDto(createdPlayer);
+    }
+
+    @Override
+    public PlayerDto updatePlayer(UUID id, CreatePlayerRequest request) {
+        Player existingPlayer = playerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Player with id " + id + " not found"));
+
+        existingPlayer.setName(request.getName());
+        existingPlayer.setNation(request.getNation());
+        existingPlayer.setAge(request.getAge());
+        existingPlayer.setTeam(request.getTeam());
+        existingPlayer.setPosition(request.getPosition());
+        existingPlayer.setAssists(request.getAssists());
+        existingPlayer.setBlocks(request.getBlocks());
+        existingPlayer.setFieldGoals(request.getFieldGoals());
+        existingPlayer.setThreePoints(request.getThreePoints());
+        existingPlayer.setTwoPoints(request.getTwoPoints());
+        existingPlayer.setPoints(request.getPoints());
+
+        Player updatedPlayer = playerRepository.save(existingPlayer);
+        return playerMapper.toDto(updatedPlayer);
+    }
+
+    @Override
+    @Transactional // <- I am not sure, we need to use this annotation or no
+    public void deletePlayer(UUID id) {
+        Player player = playerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Player not found with id: " + id));
+
+        playerRepository.delete(player);
+    }
+}


### PR DESCRIPTION
Added `PlayerService` interface and `PlayerServiceImpl` with full support for:

- Retrieving all players
- Getting top scorers
- Sorting players by name (ascending and descending)
- Fetching a player by ID
- Creating a player with duplicate name check
- Updating and deleting players by ID

Uses `PlayerRepository` and `PlayerMapper` for data access and transformation.  
Handles missing players with `EntityNotFoundException` and uses `@Transactional` for safe deletion