### PR TITLE
feat(security): added JWT authentication filter and default user setup

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/NBAAnalyticsHub.iml" filepath="$PROJECT_DIR$/NBAAnalyticsHub.iml" />
+      <module fileurl="file://$PROJECT_DIR$/backend/analyticshub.iml" filepath="$PROJECT_DIR$/backend/analyticshub.iml" />
     </modules>
   </component>
 </project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,35 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+
+
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>

--- a/backend/src/main/java/com/nba/analyticshub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/nba/analyticshub/config/SecurityConfig.java
@@ -1,5 +1,10 @@
 package com.nba.analyticshub.config;
 
+import com.nba.analyticshub.domain.entity.User;
+import com.nba.analyticshub.repository.UserRepository;
+import com.nba.analyticshub.security.JwtAuthFilter;
+import com.nba.analyticshub.security.NbaUserDetailsService;
+import com.nba.analyticshub.service.AuthService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -9,18 +14,45 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public JwtAuthFilter jwtAuthFilter(AuthService authService) {
+        return new JwtAuthFilter(authService);
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserRepository userRepository) {
+        NbaUserDetailsService nbaUserDetailsService = new NbaUserDetailsService(userRepository);
+
+        String email = "user1@test.com";
+        userRepository.findByEmail(email).orElseGet(() -> {
+            User newUser = User.builder()
+                    .name("Test User")
+                    .email(email)
+                    .password(passwordEncoder().encode("password"))
+                    .build();
+            return userRepository.save(newUser);
+        });
+
+        return  nbaUserDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            JwtAuthFilter jwtAuthFilter) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/players/**").permitAll()
                         .anyRequest().authenticated()
@@ -28,7 +60,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                );
+                ).addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/nba/analyticshub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/nba/analyticshub/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.nba.analyticshub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/players/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/controller/AuthController.java
+++ b/backend/src/main/java/com/nba/analyticshub/controller/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth/login")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;

--- a/backend/src/main/java/com/nba/analyticshub/controller/AuthController.java
+++ b/backend/src/main/java/com/nba/analyticshub/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.nba.analyticshub.controller;
+
+import com.nba.analyticshub.domain.dto.AuthResponse;
+import com.nba.analyticshub.domain.dto.LoginRequest;
+import com.nba.analyticshub.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth/login")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest loginRequest) {
+        UserDetails userDetails = authService.authenticate(
+                loginRequest.getEmail(),
+                loginRequest.getPassword()
+        );
+        String tokenValue = authService.generateToken(userDetails);
+        AuthResponse authResponse = AuthResponse.builder()
+                .token(tokenValue)
+                .expiresIn(86400)
+                .build();
+
+        return ResponseEntity.ok(authResponse);
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/controller/ErrorController.java
+++ b/backend/src/main/java/com/nba/analyticshub/controller/ErrorController.java
@@ -1,0 +1,64 @@
+package com.nba.analyticshub.controller;
+
+import com.nba.analyticshub.domain.dto.ApiErrorResponse;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.boot.model.naming.IllegalIdentifierException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ControllerAdvice
+@Slf4j
+public class ErrorController {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleException(Exception ex) {
+        log.error("Caught Exception", ex);
+        ApiErrorResponse err = ApiErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("An unexpected error occurred!")
+                .build();
+        return new ResponseEntity<>(err, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(IllegalIdentifierException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ApiErrorResponse err = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(ex.getMessage())
+                .build();
+        return new ResponseEntity<>(err, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalStateException(IllegalStateException ex) {
+        ApiErrorResponse err = ApiErrorResponse.builder()
+                .status(HttpStatus.CONFLICT.value())
+                .message(ex.getMessage())
+                .build();
+        return new ResponseEntity<>(err, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiErrorResponse> handleBadCredentialsException(BadCredentialsException ex) {
+        ApiErrorResponse err = ApiErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .message("Incorrect username or password!")
+                .build();
+        return new ResponseEntity<>(err, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
+        ApiErrorResponse err = ApiErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .message(ex.getMessage())
+                .build();
+        return new ResponseEntity<>(err, HttpStatus.NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/ApiErrorResponse.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/ApiErrorResponse.java
@@ -1,0 +1,27 @@
+package com.nba.analyticshub.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldError> errors;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FieldError {
+        private String field;
+        private String message;
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/AuthResponse.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/AuthResponse.java
@@ -1,0 +1,12 @@
+package com.nba.analyticshub.domain.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponse {
+    private String token;
+    private long expiresIn;
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/dto/LoginRequest.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/dto/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.nba.analyticshub.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/backend/src/main/java/com/nba/analyticshub/domain/entity/User.java
+++ b/backend/src/main/java/com/nba/analyticshub/domain/entity/User.java
@@ -1,0 +1,40 @@
+package com.nba.analyticshub.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/repository/UserRepository.java
+++ b/backend/src/main/java/com/nba/analyticshub/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.nba.analyticshub.repository;
+
+import com.nba.analyticshub.domain.entity.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/com/nba/analyticshub/repository/UserRepository.java
+++ b/backend/src/main/java/com/nba/analyticshub/repository/UserRepository.java
@@ -1,11 +1,13 @@
 package com.nba.analyticshub.repository;
 
 import com.nba.analyticshub.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface UserRepository {
+public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
 }

--- a/backend/src/main/java/com/nba/analyticshub/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/nba/analyticshub/security/JwtAuthFilter.java
@@ -1,0 +1,59 @@
+package com.nba.analyticshub.security;
+
+import com.nba.analyticshub.service.AuthService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final AuthService authService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            String token = extractToken(request);
+            if (token != null) {
+                UserDetails userDetails = authService.validateToken(token);
+
+                UsernamePasswordAuthenticationToken authentication =  new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                if(userDetails instanceof NbaUserDetails) {
+                    request.setAttribute("userId", ((NbaUserDetails) userDetails).getId());
+                }
+            }
+        } catch (Exception e) {
+            // Do not throw exceptions just do not authenticate the user
+            log.warn("Received invalid auth token");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/security/NbaUserDetails.java
+++ b/backend/src/main/java/com/nba/analyticshub/security/NbaUserDetails.java
@@ -1,0 +1,58 @@
+package com.nba.analyticshub.security;
+
+import com.nba.analyticshub.domain.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public class NbaUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public UUID getId() {
+        return user.getId();
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/security/NbaUserDetailsService.java
+++ b/backend/src/main/java/com/nba/analyticshub/security/NbaUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.nba.analyticshub.security;
+
+import com.nba.analyticshub.domain.entity.User;
+import com.nba.analyticshub.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@RequiredArgsConstructor
+public class NbaUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+        return new NbaUserDetails(user);
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/service/AuthService.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/AuthService.java
@@ -5,4 +5,5 @@ import org.springframework.security.core.userdetails.UserDetails;
 public interface AuthService {
     UserDetails authenticate(String email, String password);
     String generateToken(UserDetails userDetails);
+    UserDetails validateToken(String token);
 }

--- a/backend/src/main/java/com/nba/analyticshub/service/AuthService.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.nba.analyticshub.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface AuthService {
+    UserDetails authenticate(String email, String password);
+    String generateToken(UserDetails userDetails);
+}

--- a/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/AuthServiceImpl.java
@@ -1,0 +1,57 @@
+package com.nba.analyticshub.service.serviceImpl;
+
+import com.nba.analyticshub.service.AuthService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserDetailsService userDetailsService;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Long jwtExpiryMs = 86400000L;
+
+    @Override
+    public UserDetails authenticate(String email, String password) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(email, password)
+        );
+        return userDetailsService.loadUserByUsername(email);
+    }
+
+    @Override
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        long jwtExpiryMs = 86400000L;
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiryMs))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Key getSigningKey() {
+        byte[] keyBytes = secretKey.getBytes();
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/nba/analyticshub/service/serviceImpl/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.nba.analyticshub.service.serviceImpl;
 
 import com.nba.analyticshub.service.AuthService;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -48,6 +49,21 @@ public class AuthServiceImpl implements AuthService {
                 .setExpiration(new Date(System.currentTimeMillis() + jwtExpiryMs))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    @Override
+    public UserDetails validateToken(String token) {
+        String username = extractUsername(token);
+        return userDetailsService.loadUserByUsername(username);
+    }
+
+    private String extractUsername(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
     }
 
     private Key getSigningKey() {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=analyticshub
 
+jwt.secret=your-256-bit-secret-key-here-make-it-at-least-32-bytes-long
+
 spring.datasource.url=jdbc:postgresql://localhost:5432/intern
 spring.datasource.username=intern
 spring.datasource.password=max123

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,4 +6,5 @@ spring.datasource.password=max123
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### Features Implemented
- **User Entity**
  - Added `User` entity with fields: `id`, `email`, `password`, `name`, `createdAt`
  - Includes automatic `createdAt` timestamp using `@PrePersist`

- **User Repository**
  - Created `UserRepository` with `findByEmail(String email)` method

- **Login Request and Response DTOs**
  - `LoginRequest`: contains `email` and `password`
  - `AuthResponse`: contains `token` and `expiresIn`

- **Authentication Service**
  - `AuthService` interface and `AuthServiceImpl` implementation
  - Methods:
    - `authenticate(email, password)`
    - `generateToken(userDetails)`
    - `validateToken(token)`
  - Uses `io.jsonwebtoken` to generate and parse JWT tokens
- **JWT Filter**
  - `JwtAuthFilter` that extracts and validates JWT from `Authorization` header
  - Populates `SecurityContext` and attaches `userId` to the request

- **Custom `UserDetailsService`**
  - `NbaUserDetailsService` loads user from DB
  - Default test user is created if missing:
    - **Email**: `user1@test.com`
    - **Password**: `password`

- **Security Configuration**
  - CSRF disabled, stateless session policy
  - Public endpoints:
    - `POST /api/v1/auth/login`
    - `GET /api/v1/players/**`
  - All other endpoints require authentication

- **Authentication Controller**
  - `POST /api/v1/auth/login` endpoint
  - Returns `AuthResponse` with access token
